### PR TITLE
#34,#46 added datastore methods for plotting to read refreshed data

### DIFF
--- a/simulation.py
+++ b/simulation.py
@@ -9,7 +9,7 @@ import logging
 # from project_argparser import SingleArg
 from PyQt5.QtCore import (QThread, pyqtSignal, pyqtSlot)
 import cProfile
-import ptvsd
+#import ptvsd
 from datastore import (DataStore, RacingSimulationResults)
 from logging_config import configure_logging
 from physics_equations import (max_negative_power_physics_simulation,
@@ -285,7 +285,7 @@ class SimulationThread(QThread):
 
 
         """
-        ptvsd.debug_this_thread()
+        #ptvsd.debug_this_thread()
         # performance increases by assigning local functions
         # https://towardsdatascience.com/10-techniques-to-speed-up-python-runtime-95e213e925dc
         add_physics_result_to_datastore = self._data_store.add_physics_results_to_lap_results

--- a/visualization.py
+++ b/visualization.py
@@ -124,8 +124,6 @@ class MainWindow(QWidget):
 
         # Setup the SIGNALs to be received from the worker threads
         self.simulationThread.simulationThreadSignal.connect(self.signalRcvFromSimulationThread)
-        # self.simulationThread.simulationThreadWalkBackCompleteSignal.connect(self.signalWalkBackComplete)
-
 
         # internal timer for refreshing the plots
         self.plotRefreshTimer = QTimer()
@@ -293,28 +291,6 @@ class MainWindow(QWidget):
     @pyqtSlot(str)
     def signalRcvFromSimulationThread(self, text):
         self.textboxStatus.setText(text)
-
-    
-    # @pyqtSlot(int)
-    # def signalWalkBackComplete(self, walk_back_index):
-        """ This function is the handler for the signal sent from SimThread that
-        the walk back is complete. We use it to refresh the graphs from the
-        passed parameter (walk_back_index) up to sim_index by 
-        1) truncating our local copy of the plotted data arrays at dataXXX[0,walk_index] then
-        2) rewinding the plotting pointer (self.last_plotted_data=walk_back_index) then
-        let the normal refresh mechanism (signalPlotRefresh) append the data
-        from walk_back_index to current_sim_index
-
-        Args:
-            walk_back_index is the index in data_store arrays where plotted data should be 
-            now be refreshed starting at this value through the latest calculation
-            (current_sim_index) 
-        Returns: 
-            Nothing
-        """
-        #self._velocity = self._velocity[0:walk_back_index]
-        # self.last_plotted_index = walk_back_index
-        # print("walk_back_index = {}".format(walk_back_index))
 
     @pyqtSlot()
     def signalPlotRefresh(self):


### PR DESCRIPTION
Added a new get_new_data_values method in datastore to get a dictionary containing all the computed lists as well as the new refresh_index which was updated by SimulationThread which tells the consumer (MainWindow) the index where to start refreshing from. 

Tested on currently included track to see that the plots updated after SimulationThread walked back the calculations to meet the velocity constraints envelope.