### PR TITLE
added in battery energy and power to simulation

### DIFF
--- a/datastore.py
+++ b/datastore.py
@@ -151,11 +151,11 @@ class DataStore:
     def get_time_at_index(self, index):
         self._lock.lockForRead()
         try:
-            _time = self._lap_simulation_results.time_list[index]
+            _time = self._lap_simulation_results.time_cumulative_list[index]
         except IndexError:
             logger.info("index out of range: {}, returning last time",
-                        extra={'sim_index': index})
-            _time = self._lap_simulation_results.time_list[-1]
+                    extra={'sim_index': index})
+            _time = self._lap_simulation_results.time_cumulative_list[-1]
         temp = deepcopy(_time)
         self._lock.unlock()
         return temp
@@ -163,11 +163,11 @@ class DataStore:
     def get_time_list(self, num_index_samples):
         self._lock.lockForRead()
         try:
-            _time = self._lap_simulation_results.time_list[0:num_index_samples]
+            _time = self._lap_simulation_results.time_cumulative_list[0:num_index_samples]
         except IndexError:
             logger.error("index out of range: {}, returning last time",
-                         extra={'sim_index': num_index_samples})
-            _time = self._lap_simulation_results.time_list
+                    extra={'sim_index': num_index_samples})
+            _time = self._lap_simulation_results.time_cumulative_list
         temp = deepcopy(_time)
         self._lock.unlock()
         return temp
@@ -175,11 +175,11 @@ class DataStore:
     def get_time_in_range(self, begin_index, end_index):
         self._lock.lockForRead()
         try:
-            _time = self._lap_simulation_results.time_list[begin_index:end_index]
+            _time = self._lap_simulation_results.time_cumulative_list[begin_index:end_index]
         except IndexError:
             logger.error("index out of range: {}, returning last time",
-                         extra={'sim_index': end_index})
-            _time = self._lap_simulation_results.time_list[-1]
+                    extra={'sim_index': end_index})
+            _time = self._lap_simulation_results.time_cumulative_list[-1]
         temp = deepcopy(_time)
         self._lock.unlock()
         return temp
@@ -390,11 +390,11 @@ class DataStore:
     def get_distance_at_index(self, index):
         self._lock.lockForRead()
         try:
-            _distance = self._lap_simulation_results.distance_list[index]
+            _distance = self._lap_simulation_results.distance_cumulative_list[index]
         except IndexError:
             logger.error("index out of range: {}, returning last distance",
-                         extra={'sim_index': index})
-            _distance = self._lap_simulation_results.distance_list[-1]
+                    extra={'sim_index': index})
+            _distance = self._lap_simulation_results.distance_cumulative_list[-1]
         temp = deepcopy(_distance)
         self._lock.unlock()
         return temp
@@ -402,11 +402,11 @@ class DataStore:
     def get_distance_list(self, num_index_samples):
         self._lock.lockForRead()
         try:
-            _distance = self._lap_simulation_results.distance_list[0:num_index_samples]
+            _distance = self._lap_simulation_results.distance_cumulative_list[0:num_index_samples]
         except IndexError:
             logger.error("index out of range: {}, returning last distance",
-                         extra={'sim_index': num_index_samples})
-            _distance = self._lap_simulation_results.distance_list[-1]
+                    extra={'sim_index':num_index_samples})
+            _distance = self._lap_simulation_results.distance_cumulative_list[-1]
         temp = deepcopy(_distance)
         self._lock.unlock()
         return temp
@@ -414,11 +414,11 @@ class DataStore:
     def get_distance_in_range(self, begin_index, end_index):
         self._lock.lockForRead()
         try:
-            _distance = self._lap_simulation_results.distance_list[begin_index:end_index]
+            _distance = self._lap_simulation_results.distance_cumulative_list[begin_index:end_index]
         except IndexError:
             logger.error("index out of range: {}, returning last distance",
-                         extra={'sim_index': end_index})
-            _distance = self._lap_simulation_results.distance_list[-1]
+                    extra={'sim_index':end_index})
+            _distance = self._lap_simulation_results.distance_cumulative_list[-1]
         temp = deepcopy(_distance)
         self._lock.unlock()
         return temp
@@ -601,12 +601,12 @@ class LapVelocitySimulationResults():
 
         Args:
             length (int): length of output arrays, this should be the
-                          length of the track lists (ex: track.distance_list)
+                          length of the track lists (ex: track.distance_cumulative_list)
         """
         self.end_velocity = 0
         self.lap_time = 0
-        self.time_list = []
-        self.distance_list = []
+        self.time_cumulative_list = []
+        self.distance_cumulative_list = []
         self.motor_power_list = []
         self.battery_power_list = []
         self.battery_energy_list = []
@@ -619,23 +619,23 @@ class LapVelocitySimulationResults():
         the initialization of the datastore.
         """
 
-        self.time_list = []
-        self.distance_list = []
+        self.time_cumulative_list = []
+        self.distance_cumulative_list = []
         self.motor_power_list = []
-        self.battery_power_list = []
         self.motor_energy_list = []
         self.acceleration_list = []
         self.velocity_list = []
         self.battery_energy_list = []
         self.battery_power_list = []
+        self.battery_energy_cumulative_list = []
         self.physics_results_profile = []
 
         physics_result_filler = PhysicsCalculationOutput(1, 1, 1, 1, 1, 1)
 
         # length - 1 is for the because the first element is added above
         for i in range(length):
-            self.time_list.append(0)
-            self.distance_list.append(0)
+            self.time_cumulative_list.append(0)
+            self.distance_cumulative_list.append(0)
             self.motor_power_list.append(0)
             self.battery_power_list.append(0)
             self.motor_energy_list.append(0)
@@ -643,6 +643,7 @@ class LapVelocitySimulationResults():
             self.velocity_list.append(0)
             self.battery_energy_list.append(0)
             self.battery_power_list.append(0)
+            self.battery_energy_cumulative_list.append(0)
             self.physics_results_profile.append(physics_result_filler)
 
     def add_physics_results(self, physics_results, index):
@@ -655,11 +656,10 @@ class LapVelocitySimulationResults():
 
         """
         self.physics_results_profile[index] = physics_results
-
-        self.distance_list[index] = (self.distance_list[index - 1] +
-                                     physics_results.distance_traveled)
-        self.time_list[index] = (self.time_list[index - 1] +
-                                 physics_results.time_of_segment)
+        self.distance_cumulative_list[index] = (self.distance_cumulative_list[index - 1] +
+                                                physics_results.distance_traveled)
+        self.time_cumulative_list[index] = (self.time_cumulative_list[index - 1] +
+                                            physics_results.time_of_segment)
         self.motor_power_list[index] = physics_results.motor_power
         self.motor_energy_list[index] = (self.motor_energy_list[index - 1] +
                                          physics_results.energy_differential_of_motor)
@@ -667,3 +667,5 @@ class LapVelocitySimulationResults():
         self.velocity_list[index] = physics_results.final_velocity
         self.battery_energy_list[index] = physics_results.battery_energy
         self.battery_power_list[index] = physics_results.battery_power
+        self.battery_energy_cumulative_list[index] = (self.battery_energy_cumulative_list[index - 1] +
+                                                      physics_results.battery_energy)

--- a/datastore.py
+++ b/datastore.py
@@ -232,6 +232,7 @@ class DataStore:
         except IndexError:
             logger.error("index out of range: {}, returning last velocity",
                          extra={'sim_index': num_index_samples})
+
             _velocity = self._lap_simulation_results.velocity_list
         temp = deepcopy(_velocity)
         self._lock.unlock()
@@ -625,6 +626,8 @@ class LapVelocitySimulationResults():
         self.motor_energy_list = []
         self.acceleration_list = []
         self.velocity_list = []
+        self.battery_energy_list = []
+        self.battery_power_list = []
         self.physics_results_profile = []
 
         physics_result_filler = PhysicsCalculationOutput(1, 1, 1, 1, 1, 1)
@@ -638,6 +641,8 @@ class LapVelocitySimulationResults():
             self.motor_energy_list.append(0)
             self.acceleration_list.append(0)
             self.velocity_list.append(0)
+            self.battery_energy_list.append(0)
+            self.battery_power_list.append(0)
             self.physics_results_profile.append(physics_result_filler)
 
     def add_physics_results(self, physics_results, index):
@@ -660,3 +665,5 @@ class LapVelocitySimulationResults():
                                          physics_results.energy_differential_of_motor)
         self.acceleration_list[index] = physics_results.acceleration
         self.velocity_list[index] = physics_results.final_velocity
+        self.battery_energy_list[index] = physics_results.battery_energy
+        self.battery_power_list[index] = physics_results.battery_power

--- a/physics_equations.py
+++ b/physics_equations.py
@@ -277,14 +277,13 @@ def reverse_dececceleration_calculation(final_velocity,
         = rotational_kinetic_energy_calculation(rotational_inertia,
                                                 wheel_radius,
                                                 final_velocity)
-    # -1 to reverse sign of this force because the simulation is running backwards in time
-    drag_energy = -1 * distance_of_travel * drag_force_calculation(drag_coefficient,
+    drag_energy = distance_of_travel * drag_force_calculation(drag_coefficient,
                                                                    final_velocity,
                                                                    air_density,
                                                                    frontal_area)
     # -1 to reverse sign of this force because the simulation is running backwards in time
     rolling_resistance_force = \
-        -1 * rolling_resistance_force_calculation(mass, final_velocity, wheel_pressure_bar)
+        rolling_resistance_force_calculation(mass, final_velocity, wheel_pressure_bar)
     rolling_resistance_energy = rolling_resistance_force * time_of_segment
 
     initial_kinetic_energy_term = 0.5 * (rotational_inertia * ((1/wheel_radius) ** 2) +
@@ -315,13 +314,14 @@ def reverse_dececceleration_calculation(final_velocity,
                  .format(acceleration, final_velocity, initial_velocity,
                          time_of_segment, distance_of_travel),
                  extra={'sim_index': 'N/A'})
-    logger.debug("final linear e, {}, init linear e, {}, final rot e, {}, init rot e, {}"
+    logger.debug("final linear e, {}, init linear e, {}, final rot e, {}, init rot e, {}\n"
                  .format(final_linear_kinetic_energy, initial_linear_kinetic_energy,
                          final_rotational_kinetic_energy, initial_rotational_kinetic_energy),
                  extra={'sim_index': 'N/A'})
 
     physics_results = PhysicsCalculationOutput(initial_velocity, final_velocity, distance_of_travel,
                                                time_of_segment, energy_motor, acceleration)
+
     # developer check
     if final_velocity > initial_velocity:
         raise("reverse physics calculation wrong! initial velocity lower than final velocity")

--- a/physics_equations.py
+++ b/physics_equations.py
@@ -31,6 +31,8 @@ class PhysicsCalculationOutput():
         self.energy_differential_of_motor = energy_differential_of_motor
         self.acceleration = acceleration
         self.motor_power = self.energy_differential_of_motor / self.time_of_segment
+        self.battery_power = self.motor_power
+        self.battery_energy = self.energy_differential_of_motor
 
 
 def rotational_inertia_calculation(rotational_mass, effective_radius):

--- a/visualization.py
+++ b/visualization.py
@@ -237,7 +237,7 @@ class MainWindow(QWidget):
         self.checkboxBatteryEnergy.setChecked(False)
         self.spinboxBatteryEnergy = QDoubleSpinBox()
         self.spinboxBatteryEnergy.setReadOnly(True)
-        self.spinboxBatteryEnergy.setRange(-999999, 999999)
+        self.spinboxBatteryEnergy.setRange(-999999, 999999999)
 
         # self.userDisplayControlsGroup = QtGui.QGroupBox('User Display Controls')
         self.userDisplayControlsGroup = QGroupBox('User Controls')
@@ -325,7 +325,7 @@ class MainWindow(QWidget):
             updated_acceleration = dictResults['acceleration']
             updated_motor_power = dictResults['motor_power']
             updated_battery_power = dictResults['battery_power']
-            # updated_battery_energy = dictResults['battery_energy']
+            updated_battery_energy = dictResults['battery_energy']
             # print('len(_x)={} len(_velocity)={}'.format(len(self._x), len(self._velocity)))
             # print('Adding new {} velocity data points starting at index {}'.format(
             #                                                    len(updated_velocity), new_rfi))
@@ -339,7 +339,7 @@ class MainWindow(QWidget):
             self._acceleration = self._acceleration[0:new_rfi]
             self._motor_power = self._motor_power[0:new_rfi]
             self._battery_power = self._battery_power[0:new_rfi]
-            # self._battery_energy = self._battery_energy[0:new_rfi]
+            self._battery_energy = self._battery_energy[0:new_rfi]
             # print('After resizing _velocity is len={}'.format(len(self._velocity)))
 
             # append on newly retrieved data
@@ -350,7 +350,7 @@ class MainWindow(QWidget):
             self._acceleration = self._acceleration + updated_acceleration
             self._motor_power = self._motor_power + updated_motor_power
             self._battery_power = self._battery_power + updated_battery_power
-            # self._battery_energy = self._battery_energy + updated_battery_energy
+            self._battery_energy = self._battery_energy + updated_battery_energy
             self._X = list(range(0, len(self._velocity)))
             # print('After appending, len(_X) = {} len(_velocity) = {}'
             #        .format(len(self._X), len(self._velocity)))
@@ -362,7 +362,7 @@ class MainWindow(QWidget):
             self.spinboxAcceleration.setValue(self._acceleration[-1])
             self.spinboxMotorPower.setValue(self._motor_power[-1])
             self.spinboxBatteryPower.setValue(self._battery_power[-1])
-            # self.spinboxBatteryEnergy.setValue(self._battery_energy[-1])
+            self.spinboxBatteryEnergy.setValue(self._battery_energy[-1])
 
             # alway plot/show the Time plot because the other plots are "linked" to it
             # so user can scroll around
@@ -401,11 +401,9 @@ class MainWindow(QWidget):
             else:
                 self.p6.hide()
 
-            """TBD - to be added once Battery Energy is working in physics_equations
+
             if self.checkboxBatteryEnergy.isChecked() is True:
-                #self.p7.show()
-                #self.p7.plot(x=x, y=_battery_energy, name="Plot7", title="Battery Energy (joules)")
+                self.p7.show()
                 self.battery_energy_data_line.setData(self._X, self._battery_energy)
             else:
                 self.p7.hide()
-            """


### PR DESCRIPTION
I just had not had this added in yet, whoops!

Battery power and energy are set to the same as motor power and energy, they will be different later, this will at least populate the display arrays.

This pr also addresses display issues with cumulative lists. Doing physics calculations in reverse increase the complexity to display the cumulative results. This is addressed by regenerating the display lists every display update interval.